### PR TITLE
Duplicate listing for same model

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,19 +98,8 @@ test
 ### Pretrained Models
 #### All models trained for our paper
 Following are the checkpoints of each test set used in our paper. <br>
-#### Trained with Casia WebFace
-[AgeDB-C20](https://drive.google.com/file/d/1g7wol0isBX_-X1r-TlTqaJk8pVWA5W4z/view?usp=sharing) <br>
-[AgeDB-C30](https://drive.google.com/file/d/1cb3eOG-6kx7eKR_SLKHH_1cyOAWlXgRI/view?usp=sharing) <br>
-[FGNET-C20](https://drive.google.com/drive/folders/1TES-mWdrITd56TpTJtnaCY0Sj7cVeQbR?usp=sharing) <br>
-[FGNET-C30](https://drive.google.com/drive/folders/1-p2gsfpaclOvn-rFDUh1Dtj7V1WvvewK?usp=sharing) <br>
-[LAG](https://drive.google.com/drive/folders/1hY2ojyS6VKQn4YfiXYGPlVTjGzw6EsXd?usp=sharing)     
-
-#### Trained with MS1M
-[AgeDB-C20](https://drive.google.com/file/d/1RFlHFqolCfDlZl43pHMoQOzobbn0MsaY/view?usp=sharing) <br>
-[AgeDB-C30](https://drive.google.com/file/d/1O6th4Vz7tOZUzxs5Y5cs4BMw-amdqHz7/view?usp=sharing) <br>
-[FGNET-C20](https://drive.google.com/file/d/1xv8yh61owP3Ls7Duzb4UogaLeOTGDQup/view?usp=sharing) <br>
-[FGNET-C30](https://drive.google.com/file/d/15CBlPCk81k4ZVP2qNnN59fQfGrTIrsLW/view?usp=sharing) <br>
-[LAG](https://drive.google.com/file/d/1vqOEgYRxe2ej2FPIf_OFTx62T06SEGy9/view?usp=sharing)     
+[Trained with Casia WebFace](https://drive.google.com/file/d/1g7wol0isBX_-X1r-TlTqaJk8pVWA5W4z/view?usp=sharing)  
+[Trained with MS1M](https://drive.google.com/file/d/1RFlHFqolCfDlZl43pHMoQOzobbn0MsaY/view?usp=sharing)
 ```
 CUDA_VISIBLE_DEVICES=0 python3 evaluate.py --model_dir=<test_dir>
 ```


### PR DESCRIPTION
I've removed multiple listing for the same model. Previously for each model trained on CASIA WebFace and MS1MV2, there were 5 listings named acc. to the test set, which doesn't make sense because the model would remain the same. I've also checked the hashes of the files and they were the same.